### PR TITLE
Fix regression to always ask for account name verification

### DIFF
--- a/nubis-ctl
+++ b/nubis-ctl
@@ -450,7 +450,6 @@ nubis-build() {
 setup-account() {
     if [ -z "${NUBIS_ACCOUNT}" ]; then
         ask-for-input "Enter the AWS Account name:" NUBIS_ACCOUNT
-    else
         echo "I have account '${NUBIS_ACCOUNT}'. Is this correct?"
         PS3="Enter a number: "
         select ANSWER in 'Yes' 'No' 'Quit'; do


### PR DESCRIPTION
We should not verify if it is already set.